### PR TITLE
#88 at skycoin/skywire. Return 400 with appropriate message

### DIFF
--- a/skycoin-messenger/monitor/monitor.go
+++ b/skycoin-messenger/monitor/monitor.go
@@ -616,30 +616,38 @@ func (m *Monitor) UpdatePass(w http.ResponseWriter, r *http.Request) (result []b
 	if !verifyLogin(w, r, true) {
 		return
 	}
+
 	oldPass := r.FormValue("oldPass")
 	newPass := r.FormValue("newPass")
 	if len(oldPass) < 4 || len(oldPass) > 20 {
-		result = []byte("Old password length is 4~20.")
+		code = 400
+		err = errors.New("Old password length is 4~20.")
 		return
 	}
 	if len(newPass) < 4 || len(newPass) > 20 {
-		result = []byte("New password length is 4~20.")
+		code = 400
+		err = errors.New("New password length is 4~20.")
 		return
 	}
 	if newPass == "1234" {
-		result = []byte("Please do not change the default password.")
+		code = 400
+		err = errors.New("Please do not change the default password.")
 		return
 	}
+
 	err = checkPass(oldPass)
 	if err != nil {
-		result = []byte("The original password is wrong, please confirm again and try again.")
+		code = 400
+		err = errors.New("The original password is wrong, please confirm again and try again.")
 		return
 	}
 	err = WriteConfig(&User{Pass: getBcrypt(newPass)}, userPath)
 	if err != nil {
-		result = []byte("The server is busy. Please try again later.")
+		code = 400
+		err = errors.New("The server is busy. Please try again later.")
 		return
 	}
+
 	globalSessions.SessionDestroy(w, r)
 	result = []byte("true")
 	return


### PR DESCRIPTION
I've found an [issue #88](https://github.com/skycoin/skywire/issues/88) in the skycoin/skywire repository and I tried to fix it. 

This pull request modifies the error message of the UpdatePass function. 
I've added some code that returns the status code and error message to a user.

Please, let me know if I should update something else in the code base of skycoin/net repo to make the fix complete.

